### PR TITLE
fix format about ~/.kivy/config.ini

### DIFF
--- a/GUI/RASPBERRY_PI/README.md
+++ b/GUI/RASPBERRY_PI/README.md
@@ -282,8 +282,8 @@ We've put all the necessary steps here, so there's no need for you to jump to th
     ```
     and search (`Ctrl+W`) for `[input]` and add the following two lines
     ```
-    $ mtdev_%(name)s = probesysfs,provider=mtdev
-    $ hid_%(name)s = probesysfs,provider=hidinput
+    mtdev_%(name)s = probesysfs,provider=mtdev
+    hid_%(name)s = probesysfs,provider=hidinput
     ```
     <p align="center">
     <img src="./IMAGES/script08.jpg" width="400" alt="">


### PR DESCRIPTION
Form the picture, there should not be `$`. Guess a typo. Yeah, I am reproducing the sanp breakdown.

And, now the kivy can be install via pip(pip install kivy). Build from source may use the dev version if he or she not know how use git to checkout